### PR TITLE
switch from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,15 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.1
+    - name: Run awesome_bot
+      run: |
+        gem install awesome_bot
+        awesome_bot --allow-redirect --skip-save-results README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm: 2.4
-cache: bundler
-before_script:
-  - gem install awesome_bot
-script:
-  - awesome_bot --allow-redirect --skip-save-results -w pullapprove README.md


### PR DESCRIPTION
This removes pullapprove.com from the URL allowlist (was added in 8cc59edbb20) to see if this was unique to travis-ci infrastructure.  We can always add it back if needed.

Fixes #40